### PR TITLE
export d3 to global when using the standalone package so that users c…

### DIFF
--- a/lib/standalone.ts
+++ b/lib/standalone.ts
@@ -1,2 +1,13 @@
+import d3 = require('d3');
+
 require('./core');
 require('./viz');
+
+declare var window: any;
+declare var global: any;
+
+if (typeof window !== 'undefined') {
+    window.d3 = d3;
+} else if (typeof global !== 'undefined') {
+    global.d3 = d3;
+}


### PR DESCRIPTION
…an continue to use things like formatters.
