### PR TITLE
Add project ID to API

### DIFF
--- a/lib/core/api.ts
+++ b/lib/core/api.ts
@@ -108,10 +108,12 @@ module Api {
     
     export class Client {
         _baseUrl: string;
+        _projectId: string;
         _apiKey: string;
 
-        constructor(baseUrl: string, apiKey: string) {
+        constructor(baseUrl: string, projectId: string, apiKey: string) {
             this._baseUrl = baseUrl;
+            this._projectId = projectId;
             this._apiKey = apiKey;
         }
 
@@ -142,7 +144,8 @@ module Api {
             var deferred = Q.defer();
 
             requestToSend
-                .set('X-API-Key', this._apiKey)
+                .set('X-Project-Id', this._projectId)
+                .set('X-Api-Key', this._apiKey)
                 .end((err: any, res: request.Response) => {
                     if(err) {
                         if(!err.status) {

--- a/lib/core/config.ts
+++ b/lib/core/config.ts
@@ -1,6 +1,7 @@
 module Config {
 	export interface ConnectConfig {
-		baseUrl?: string; 
+		baseUrl?: string;
+		projectId: string;
 		apiKey: string;
 	}
 }

--- a/lib/core/connect.ts
+++ b/lib/core/connect.ts
@@ -37,6 +37,7 @@ class Connect implements Viz.Visualizations {
     private getConfig(config: Config.ConnectConfig): Config.ConnectConfig {
         return {
             baseUrl: config.baseUrl || 'https://api.getconnect.io',
+            projectId: config.projectId,
             apiKey: config.apiKey
         };  
     }

--- a/test/connect-spec.ts
+++ b/test/connect-spec.ts
@@ -14,7 +14,8 @@ describe('Connect', () => {
 
 	before(() => {
 		connect = new Connect({
-			apiKey: 'abc'
+			apiKey: 'abc',
+			projectId: 'abc'
 		});
 	});
 


### PR DESCRIPTION
The new API implementing projects requires a project ID for push and query - this now supports that.
