### PR TITLE
Warns rather than fails when the supplied DOM element is not found

### DIFF
--- a/lib/viz/viz-renderer.ts
+++ b/lib/viz/viz-renderer.ts
@@ -23,8 +23,13 @@ class VizRenderer {
     constructor(targetElement: string|HTMLElement, data: Queries.ConnectQuery|Api.QueryResultsFactory, 
         options: Config.VisualizationOptions, visualization: Common.Visualization) {
 
-        this._queryResultsFactory = this._getQueryResultsFactory(data);
         this._targetElement = Dom.getElement(targetElement);
+        if (!this._targetElement) {
+            console.warn(`Warning: The supplied container ${targetElement} could not be found.`);
+            return;
+        }
+
+        this._queryResultsFactory = this._getQueryResultsFactory(data);
         this._visualization = visualization;
         this._resultHandler = new ResultHandling.ResultHandler(this._targetElement);
         this._options = options;


### PR DESCRIPTION
Do we feel the warning message is descriptive enough?
